### PR TITLE
return empty array if no valid hosts are found

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,10 @@ function parse(configString) {
     .map(trim)
     .filter(nonComment)
     .filter(nonEmptyString);
+
+  if (! values.length)
+    return [];
+
   var entries = [];
 
   hostLines.forEach(function(hostLine, i) {


### PR DESCRIPTION
The module would throw an error if you feed it a file full of comments, some of which have the word "Host" in them (specifically, it happened on line 53-54 when `hostLines` is an array, while `values` is empty after having been purged of commented out lines).

The default `/etc/ssh/ssh_config` on my distro threw said error, this simple change just makes it return an empty array if ssh config is valid but has commented out examples